### PR TITLE
Use `stable` as Go version in GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: stable
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4


### PR DESCRIPTION
Use `stable` as Go version in GitHub Action.
